### PR TITLE
Add pluginRepositories section for SNAPSHOTs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,16 @@ under the License.
       </releases>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
Enable more convenient utilization of SNAPSHOT versions of
plugins deployed to ASF's Maven repositories. This is
useful for testing plugins prior to their release.