### PR TITLE
[MPOM-209]. Corrected Jira URL.

### DIFF
--- a/site-pom.xml
+++ b/site-pom.xml
@@ -44,7 +44,7 @@ under the License.
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.apache.org/jira/browse/MPOM/component/12314370</url>
+    <url>https://issues.apache.org/jira/issues/?jql=project%3DMPOM+AND+component%3Dasf</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>


### PR DESCRIPTION
Thanks for the comments @hboutemy ! I also think this URL is cleaner this way without the whitespaces. I'd prefer to keep the %3D just in case.