### PR TITLE
[MPOM-256] Remove outdated clirr-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,11 +317,6 @@ under the License.
           <artifactId>apache-rat-plugin</artifactId>
           <version>0.13</version>
         </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>clirr-maven-plugin</artifactId>
-          <version>2.8</version>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/maven-apache-parent/27)
<!-- Reviewable:end -->
