### PR TITLE
[MPOM-260] simplify m-javadoc-p configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,7 @@ under the License.
     <arguments />
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <surefire.version>2.22.2</surefire.version>
-    <maven.javadoc.version>3.2.0</maven.javadoc.version>
+    <surefire.version>2.22.2</surefire.version><!-- for surefire, failsafe and surefire-report -->
     <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
     <!-- set this property for all derived projects:
     <project.build.outputTimestamp>2020-01-22T15:10:38Z</project.build.outputTimestamp>
@@ -214,10 +213,9 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven.javadoc.version}</version>
-          <!-- due to https://issues.apache.org/jira/browse/MNG-7006 duplicate reporting configuration -->
+          <version>3.2.0</version>
           <configuration>
-            <notimestamp>true</notimestamp>
+            <notimestamp>true</notimestamp><!-- avoid noise for svn/gitpubsub -->
           </configuration>
         </plugin>
         <plugin>
@@ -356,19 +354,6 @@ under the License.
       </plugin>
     </plugins>
   </build>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven.javadoc.version}</version>
-        <configuration>
-          <notimestamp>true</notimestamp>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 
   <profiles>
     <!-- START SNIPPET: release-profile -->


### PR DESCRIPTION
after discussion in #31 regarding what is supported since Maven Site Plugin 3.4 (see reference documentation https://maven.apache.org/shared/maven-reporting-exec/ and https://maven.apache.org/plugins/maven-site-plugin/history.html)