### PR TITLE
Stage site build (that uses site-pom.xml)

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
+    with:
+      ff-site-goal: 'site site:stage -f site-pom.xml'


### PR DESCRIPTION
Corresponding to the latest change in shared action.

https://github.com/apache/maven-gh-actions-shared/pull/40

Site build output is attached to action build, can be downloaded and check result.