### PR TITLE
[MPOM-378] Using an SPDX identifier as the license name is recommended by Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ under the License.
   </organization>
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
See: https://maven.apache.org/pom.html#Licenses and https://spdx.org/licenses/

(Also: Trying to get the SPDX plugin to pick this up)