### PR TITLE
[MPOM-332] Remove outdated m-deploy-p configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,15 +416,6 @@ under the License.
               </execution>
             </executions>
           </plugin>
-          <!-- We want to deploy the artifact to a staging location for perusal -->
-          <plugin>
-            <inherited>true</inherited>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <updateReleaseInfo>true</updateReleaseInfo>
-            </configuration>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
There is no parameter updateReleaseInfo in current plugin version