### PR TITLE
[MPOM-289] Use properties for all plugin versions (alternate)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,16 +109,13 @@ under the License.
     <version.maven-deploy-plugin>3.1.1</version.maven-deploy-plugin>
     <version.maven-ear-plugin>3.3.0</version.maven-ear-plugin>
     <version.maven-enforcer-plugin>3.3.0</version.maven-enforcer-plugin>
-    <version.maven-failsafe-plugin>${surefire.version}</version.maven-failsafe-plugin>
     <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
     <version.maven-help-plugin>3.4.0</version.maven-help-plugin>
     <version.maven-install-plugin>3.1.1</version.maven-install-plugin>
     <version.maven-invoker-plugin>3.5.1</version.maven-invoker-plugin>
     <version.maven-jar-plugin>3.3.0</version.maven-jar-plugin>
     <version.maven-javadoc-plugin>3.5.0</version.maven-javadoc-plugin>
-    <version.maven-plugin-annotations>${maven.plugin.tools.version}</version.maven-plugin-annotations>
-    <version.maven-plugin-plugin>${maven.plugin.tools.version}</version.maven-plugin-plugin>
-    <version.maven-plugin-report-plugin>${maven.plugin.tools.version}</version.maven-plugin-report-plugin>
+    <version.maven-plugin-tools>${maven.plugin.tools.version}</version.maven-plugin-tools>
     <version.maven-project-info-reports-plugin>3.4.3</version.maven-project-info-reports-plugin>
     <version.maven-release-plugin>3.0.1</version.maven-release-plugin>
     <version.maven-remote-resources-plugin>3.1.0</version.maven-remote-resources-plugin>
@@ -128,8 +125,7 @@ under the License.
     <version.maven-shade-plugin>3.4.1</version.maven-shade-plugin>
     <version.maven-site-plugin>3.12.1</version.maven-site-plugin>
     <version.maven-source-plugin>3.3.0</version.maven-source-plugin>
-    <version.maven-surefire-plugin>${surefire.version}</version.maven-surefire-plugin>
-    <version.maven-surefire-report-plugin>${surefire.version}</version.maven-surefire-report-plugin>
+    <version.maven-surefire>${surefire.version}</version.maven-surefire>
     <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
   </properties>
 
@@ -138,7 +134,7 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${version.maven-plugin-annotations}</version>
+        <version>${version.maven-plugin-tools}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -211,7 +207,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${version.maven-failsafe-plugin}</version>
+          <version>${version.maven-surefire}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -262,12 +258,12 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>${version.maven-plugin-plugin}</version>
+          <version>${version.maven-plugin-tools}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-report-plugin</artifactId>
-          <version>${version.maven-plugin-report-plugin}</version>
+          <version>${version.maven-plugin-tools}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -324,12 +320,12 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${version.maven-surefire-plugin}</version>
+          <version>${version.maven-surefire}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>${version.maven-surefire-report-plugin}</version>
+          <version>${version.maven-surefire}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,40 @@ under the License.
     <maven.plugin.tools.version>3.9.0</maven.plugin.tools.version><!-- for m-plugin-p and maven-plugin-annotations -->
     <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
     <project.build.outputTimestamp>2022-12-11T19:18:25Z</project.build.outputTimestamp>
+
+    <version.apache-rat-plugin>0.15</version.apache-rat-plugin>
+    <version.apache-source-release-assembly-descriptor>1.5</version.apache-source-release-assembly-descriptor>
+    <version.checksum-maven-plugin>1.11</version.checksum-maven-plugin>
+    <version.maven-antrun-plugin>3.1.0</version.maven-antrun-plugin>
+    <version.maven-assembly-plugin>3.6.0</version.maven-assembly-plugin>
+    <version.maven-clean-plugin>3.2.0</version.maven-clean-plugin>
+    <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
+    <version.maven-dependency-plugin>3.6.0</version.maven-dependency-plugin>
+    <version.maven-deploy-plugin>3.1.1</version.maven-deploy-plugin>
+    <version.maven-ear-plugin>3.3.0</version.maven-ear-plugin>
+    <version.maven-enforcer-plugin>3.3.0</version.maven-enforcer-plugin>
+    <version.maven-failsafe-plugin>${surefire.version}</version.maven-failsafe-plugin>
+    <version.maven-gpg-plugin>3.1.0</version.maven-gpg-plugin>
+    <version.maven-help-plugin>3.4.0</version.maven-help-plugin>
+    <version.maven-install-plugin>3.1.1</version.maven-install-plugin>
+    <version.maven-invoker-plugin>3.5.1</version.maven-invoker-plugin>
+    <version.maven-jar-plugin>3.3.0</version.maven-jar-plugin>
+    <version.maven-javadoc-plugin>3.5.0</version.maven-javadoc-plugin>
+    <version.maven-plugin-annotations>${maven.plugin.tools.version}</version.maven-plugin-annotations>
+    <version.maven-plugin-plugin>${maven.plugin.tools.version}</version.maven-plugin-plugin>
+    <version.maven-plugin-report-plugin>${maven.plugin.tools.version}</version.maven-plugin-report-plugin>
+    <version.maven-project-info-reports-plugin>3.4.3</version.maven-project-info-reports-plugin>
+    <version.maven-release-plugin>3.0.1</version.maven-release-plugin>
+    <version.maven-remote-resources-plugin>3.1.0</version.maven-remote-resources-plugin>
+    <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
+    <version.maven-scm-plugin>2.0.1</version.maven-scm-plugin>
+    <version.maven-scm-publish-plugin>3.2.1</version.maven-scm-publish-plugin>
+    <version.maven-shade-plugin>3.4.1</version.maven-shade-plugin>
+    <version.maven-site-plugin>3.12.1</version.maven-site-plugin>
+    <version.maven-source-plugin>3.3.0</version.maven-source-plugin>
+    <version.maven-surefire-plugin>${surefire.version}</version.maven-surefire-plugin>
+    <version.maven-surefire-report-plugin>${surefire.version}</version.maven-surefire-report-plugin>
+    <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
   </properties>
 
   <dependencyManagement>
@@ -104,7 +138,7 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven.plugin.tools.version}</version>
+        <version>${version.maven-plugin-annotations}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -137,52 +171,52 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>${version.maven-antrun-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>${version.maven-assembly-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>${version.maven-clean-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>${version.maven-compiler-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>${version.maven-dependency-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>${version.maven-deploy-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-ear-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>${version.maven-ear-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>${version.maven-enforcer-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${surefire.version}</version>
+          <version>${version.maven-failsafe-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>${version.maven-gpg-plugin}</version>
           <configuration>
             <gpgArguments>
               <arg>--digest-algo=SHA512</arg>
@@ -192,22 +226,22 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-help-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>${version.maven-help-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>${version.maven-install-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>${version.maven-invoker-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>${version.maven-jar-plugin}</version>
           <configuration>
             <archive>
               <manifest>
@@ -220,7 +254,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>${version.maven-javadoc-plugin}</version>
           <configuration>
             <notimestamp>true</notimestamp><!-- avoid noise for svn/gitpubsub -->
           </configuration>
@@ -228,17 +262,17 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>${maven.plugin.tools.version}</version>
+          <version>${version.maven-plugin-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-report-plugin</artifactId>
-          <version>${maven.plugin.tools.version}</version>
+          <version>${version.maven-plugin-report-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.3</version>
+          <version>${version.maven-project-info-reports-plugin}</version>
           <configuration>
             <pluginManagementExcludes>
               <exclude>org.eclipse.m2e:lifecycle-mapping</exclude>
@@ -249,7 +283,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>${version.maven-release-plugin}</version>
           <configuration>
             <useReleaseProfile>false</useReleaseProfile>
             <goals>deploy</goals>
@@ -260,57 +294,57 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>${version.maven-remote-resources-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>${version.maven-resources-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>2.0.1</version>
+          <version>${version.maven-scm-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-publish-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>${version.maven-scm-publish-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.12.1</version>
+          <version>${version.maven-site-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>${version.maven-source-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire.version}</version>
+          <version>${version.maven-surefire-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>${surefire.version}</version>
+          <version>${version.maven-surefire-report-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>${version.maven-war-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>${version.maven-shade-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.15</version>
+          <version>${version.apache-rat-plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -396,7 +430,7 @@ under the License.
               <dependency>
                 <groupId>org.apache.apache.resources</groupId>
                 <artifactId>apache-source-release-assembly-descriptor</artifactId>
-                <version>1.5</version>
+                <version>${version.apache-source-release-assembly-descriptor}</version>
               </dependency>
             </dependencies>
             <executions>
@@ -444,7 +478,7 @@ under the License.
           <plugin>
             <groupId>net.nicoulaj.maven.plugins</groupId>
             <artifactId>checksum-maven-plugin</artifactId>
-            <version>1.11</version>
+            <version>${version.checksum-maven-plugin}</version>
             <executions>
               <execution>
                 <id>source-release-checksum</id>
@@ -508,7 +542,7 @@ under the License.
                       <pluginExecutionFilter>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-remote-resources-plugin</artifactId>
-                        <versionRange>[0,1.8.0)</versionRange>
+                        <versionRange>[0,)</versionRange>
                         <goals>
                           <goal>process</goal>
                         </goals>

--- a/src/site-docs/apt/index.apt.vm
+++ b/src/site-docs/apt/index.apt.vm
@@ -64,7 +64,15 @@ Apache Software Foundation Parent POM
  * <<pluginManagement>>: The plugin management section specifies versions
     of a list of plugins. See the {{{./plugin-management.html}Plugin Management report}} for
     the complete list with versions. 
-    
+
+  ** There are used properties <<<version.\<artifactId\>>>> for defining each version of plugin, except:
+
+   *** <<<version.maven-plugin-tools>>> is used for: <maven-plugin-annotations>, <maven-plugin-plugin> and <maven-plugin-report-plugin>
+
+   *** <<<version.maven-surefire>>> is used for: <maven-failsafe-plugin>, <maven-surefire-plugin> and <maven-surefire-report-plugin>
+
+   []
+
   ** The compiler plugin is set to default to <<Java $context.get("maven.compiler.target")>> (<<<maven.compiler.target>>> property)
      and $context.get("project.build.sourceEncoding") source (<<<project.build.sourceEncoding>>> property).
     


### PR DESCRIPTION
Alternate implementation to PR #155 to demonstrate my alternative
proposal with the naming convention of `version.artifactId` for
properties. The properties are sorted in the properties section.

This also includes individual properties for the plugins that use
`${maven.plugin.tools.version}` and `${surefire.version}`, so they can
be set individually, but will default to using the current properties
that set the version for multiple plugins at once.

This also fixes the M2Eclipse profile, `only-eclipse`, to remove the
upper bound on the version for maven-remote-resources-plugin, because
the version specified in this POM has already exceeded the that upper
bound, and the profile would not have been working correctly.