### PR TITLE
[MPOM-430] Bump maven-javadoc-plugin from 3.5.0 to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ under the License.
     <version.maven-install-plugin>3.1.1</version.maven-install-plugin>
     <version.maven-invoker-plugin>3.5.1</version.maven-invoker-plugin>
     <version.maven-jar-plugin>3.3.0</version.maven-jar-plugin>
-    <version.maven-javadoc-plugin>3.5.0</version.maven-javadoc-plugin>
+    <version.maven-javadoc-plugin>3.6.0</version.maven-javadoc-plugin>
     <version.maven-plugin-tools>${maven.plugin.tools.version}</version.maven-plugin-tools>
     <version.maven-project-info-reports-plugin>3.4.5</version.maven-project-info-reports-plugin>
     <version.maven-release-plugin>3.0.1</version.maven-release-plugin>


### PR DESCRIPTION
This PR upgrades the maven-javadoc-plugin to the newest version. 

JIRA ticket: https://issues.apache.org/jira/browse/MPOM-430