### PR TITLE
[MPOM-451] Remove repository elements from Apache Parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,27 +142,6 @@ under the License.
     </dependencies>
   </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Snapshot repositories interfere with downstream builds