### PR TITLE
[MPOM-451] Move snapshot repositories in a profile

### DIFF
--- a/docs/src/site/apt/index.apt.vm
+++ b/docs/src/site/apt/index.apt.vm
@@ -47,8 +47,10 @@ Apache Software Foundation Parent POM
     
   ** <<url>>: {{<<<https://www.apache.org/>>>}}. You should override this.
     
-  ** <<repositories>>: The pom adds the Apache snapshot
+  ** <<repositories>>: Optional: the pom adds the Apache snapshot
      repository ({{<<<https://repository.apache.org/snapshots>>>}})
+     This only happens if the <<<apache.snapshots>>> property is set,
+     or the <<<use-apache-snapshots>>> profile is active.
     
   ** <<distributionManagement>>: The POM sets up for releases to the Apache Nexus
      instance at
@@ -191,6 +193,11 @@ Notices
 
    When you need publish site descriptor in your project you should add, like:
 
+ * Since version <<34>> <<<repositories>>> section has been moved to the <<<use-apache-snapshots>>> profile.
+
+   Apache snapshot repository is now optional, and is only added when the profile is activated.
+
+   It can be activated by setting the <<<apache.snapshots>>> property or activating the <<<use-apache-snapshots>>> profile directly.
 +------+
 <build>
   <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -137,27 +137,6 @@ under the License.
     <version.maven-war-plugin>3.4.0</version.maven-war-plugin>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -567,6 +546,34 @@ under the License.
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <profile>
+      <id>use-apache-snapshots</id>
+      <activation>
+        <property>
+          <name>apache.snapshots</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>apache.snapshots</id>
+          <name>Apache Snapshot Repository</name>
+          <url>https://repository.apache.org/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>apache.snapshots</id>
+          <name>Apache Snapshot Repository</name>
+          <url>https://repository.apache.org/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Snapshot repositories interfere with downstream builds
Besides dependabot issues, this also causes issues with old
artifacts being brought in by https://github.com/shrinkwrap/resolver with Maven 3
Maven 4, however, works around that issue.

Both of those issues are very difficult to debug, so removing the SNAPSHOT repository
by default prevents 10s of hours of debugging and troubleshooting 

Fixes https://github.com/dependabot/dependabot-core/issues/8329