### PR TITLE
Disable matrix build on GitHub

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,6 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      matrix-enabled: false
+


### PR DESCRIPTION
Similar like on Jenkins - we use one build for simple project