### PR TITLE
Update minimum maven version to match current stable version (3.6.3 -> 3.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ under the License.
     <gpg.useagent>true</gpg.useagent>
     <!-- java version used to to set maven.compiler.* -->
     <javaVersion>8</javaVersion>
-    <minimalMavenBuildVersion>3.6.3</minimalMavenBuildVersion>
+    <minimalMavenBuildVersion>3.9</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>${javaVersion}</minimalJavaBuildVersion>
     <!-- for surefire, failsafe and surefire-report -->
     <surefire.version>3.5.4</surefire.version>


### PR DESCRIPTION
According to https://maven.apache.org/docs/history.html:
> Maven 3.6.3 and before has now reached its end of life and is no longer supported in any way.

This PR updates the version to current stable version 3.9.11