### PR TITLE
Revert "Bump org.apache.rat:apache-rat-plugin from 0.16.1 to 0.17 (#544)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
 
     <project.build.outputTimestamp>2025-06-09T20:48:32Z</project.build.outputTimestamp>
 
-    <version.apache-rat-plugin>0.17</version.apache-rat-plugin>
+    <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
     <version.apache-resource-bundles>1.7</version.apache-resource-bundles>
     <version.checksum-maven-plugin>1.11</version.checksum-maven-plugin>
     <version.maven-antrun-plugin>3.2.0</version.maven-antrun-plugin>


### PR DESCRIPTION
This reverts commit a9520f4cd4619479c32a470b30f3fb6ce0a938ba.

Due to:
 - https://issues.apache.org/jira/browse/RAT-524