### PR TITLE
Set source and target in jdk9+ profile

### DIFF
--- a/docs/src/site/apt/index.apt.vm
+++ b/docs/src/site/apt/index.apt.vm
@@ -82,6 +82,8 @@ Apache Software Foundation Parent POM
 
 +------+
   <maven.compiler.release>\${javaVersion}</maven.compiler.release>
+  <maven.compiler.source>\${javaVersion}</maven.compiler.source>
+  <maven.compiler.target>\${javaVersion}</maven.compiler.target>
 +------+
 
     []

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,9 @@ under the License.
       <properties>
         <!-- https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html, affects m-compiler-p and m-javadoc-p -->
         <maven.compiler.release>${javaVersion}</maven.compiler.release>
+        <!-- also set source and target for other plugins that use these -->
+        <maven.compiler.source>${javaVersion}</maven.compiler.source>
+        <maven.compiler.target>${javaVersion}</maven.compiler.target>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Use `javaVersion` to set `maven.compiler.source` and `maven.compiler.target`, in addition to `maven.compiler.release` in the `jdk9+` profile, because some plugins still use these properties, even when `maven.compiler.release` is set. So, it is still useful to have these set automatically by the single property, `javaVersion`.