### PR TITLE
Revert workaround for parallel PUT on release

### DIFF
--- a/docs/src/site/apt/index.apt.vm
+++ b/docs/src/site/apt/index.apt.vm
@@ -86,10 +86,6 @@ Apache Software Foundation Parent POM
 
     []
 
-  ** <<releaseParallelPut>>: When doing a release, this property controls whether artifacts are uploaded in parallel (true) or sequentially (false).
-
-    Due to Nexus bug with parallel staging creation default is <<false>>.
-
  * <<pluginManagement>>: The plugin management section specifies versions
     of a list of plugins. See the {{{./plugin-management.html}Plugin Management report}} for
     the complete list with versions. 

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,6 @@ under the License.
     <surefire.version>3.5.4</surefire.version>
     <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
 
-    <releaseParallelPut>false</releaseParallelPut>
-
     <project.build.outputTimestamp>2026-01-09T19:00:31Z</project.build.outputTimestamp>
 
     <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
@@ -278,7 +276,6 @@ under the License.
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <goals>deploy</goals>
             <releaseProfiles>apache-release</releaseProfiles>
-            <arguments>-Daether.connector.basic.parallelPut=${releaseParallelPut}</arguments>
           </configuration>
         </plugin>
         <!-- END SNIPPET: release-plugin-configuration -->


### PR DESCRIPTION
This reverts commit 62692ce0

fixed in Maven 3.9.13
- https://github.com/apache/maven/issues/11634