### PR TITLE
#586: Use RAT0.18 and remove commons-lang3 configuration for JDK25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
 
     <project.build.outputTimestamp>2026-06-25T18:51:10Z</project.build.outputTimestamp>
 
-    <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
+    <version.apache-rat-plugin>0.18</version.apache-rat-plugin>
     <version.apache-resource-bundles>1.8</version.apache-resource-bundles>
     <version.checksum-maven-plugin>1.11</version.checksum-maven-plugin>
     <version.maven-antrun-plugin>3.2.0</version.maven-antrun-plugin>
@@ -345,16 +345,6 @@ under the License.
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <version>${version.apache-rat-plugin}</version>
-          <dependencies>
-            <!-- avoid - WARNING: Use of the three-letter time zone ID ... on JDK 25 -->
-            <!-- https://issues.apache.org/jira/browse/RAT-490 -->
-            <!-- TODO remove with next version of RAT -->
-            <dependency>
-              <groupId>org.apache.commons</groupId>
-              <artifactId>commons-lang3</artifactId>
-              <version>3.20.0</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.tooling</groupId>


### PR DESCRIPTION
Enable RAT0.18.

As RAT0.18 needs at least JDK17 I'm not sure which repos contain the actual plugin configuration, so this is a first draft PR.

Triggered by https://github.com/apache/maven-apache-parent/pull/574 @slawekjaranowski @slachiewicz 