### PR TITLE
[#360] Publish SBOM on ASF releases

### DIFF
--- a/docs/src/site/markdown/index.md.vm
+++ b/docs/src/site/markdown/index.md.vm
@@ -130,6 +130,8 @@ The `push-to-atr` Profile
 
 Since release 39, `push-to-atr` profile is provided to help upload built release content to [Apache Tooling](https://tooling.apache.org/)'s Trusted Releases platform, and compose the release using [`atr-maven-plugin`](https://apache.github.io/tooling-atr-maven-plugin/).
 
+When this profile is active, an aggregate CycloneDX SBOM is generated during the `package` phase. Only JSON is generated and `outputReactorProjects` is disabled, so multi-module builds produce one aggregate SBOM rather than one SBOM per module. The SBOM, its SHA-512 checksum, and its signature are uploaded to ATR alongside the source release artifacts. Projects can disable SBOM generation with `-Dcyclonedx.skip=true`.
+
 See ATR's [tutorial](https://release-test.apache.org/tutorial) for a quick introduction: check existing [committes in ATR](https://release-test.apache.org/committees), you may have to create a project or improve its configuration, for example using [`project` entry in `.asf.yaml`](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#project). Once project is ready, start the release in ATR before doing the staging release with Maven with `mvn release:perform -Ppush-to-atr`.
 
 Remember that:

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@ under the License.
     <version.apache-rat-plugin>0.18</version.apache-rat-plugin>
     <version.atr-maven-plugin>1.0.0-alpha-1</version.atr-maven-plugin>
     <version.checksum-maven-plugin>1.11</version.checksum-maven-plugin>
+    <version.cyclonedx-maven-plugin>2.9.3</version.cyclonedx-maven-plugin>
     <version.maven-antrun-plugin>3.2.0</version.maven-antrun-plugin>
     <version.maven-assembly-plugin>3.8.0</version.maven-assembly-plugin>
     <version.maven-checkstyle-plugin>3.6.0</version.maven-checkstyle-plugin>
@@ -368,6 +369,11 @@ under the License.
           <artifactId>atr-maven-plugin</artifactId>
           <version>${version.atr-maven-plugin}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${version.cyclonedx-maven-plugin}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -543,6 +549,43 @@ under the License.
       <build>
         <plugins>
           <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <configuration>
+              <outputFormat>json</outputFormat>
+              <outputReactorProjects>false</outputReactorProjects>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>makeAggregateBom</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.nicoulaj.maven.plugins</groupId>
+            <artifactId>checksum-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>cyclonedx-checksum</id>
+                <goals>
+                  <goal>artifacts</goal>
+                </goals>
+                <phase>post-integration-test</phase>
+                <configuration>
+                  <algorithms>
+                    <algorithm>SHA-512</algorithm>
+                  </algorithms>
+                  <includeClassifiers>cyclonedx</includeClassifiers>
+                  <excludeMainArtifact>true</excludeMainArtifact>
+                  <csvSummary>false</csvSummary>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.tooling</groupId>
             <artifactId>atr-maven-plugin</artifactId>
             <executions>
@@ -562,6 +605,9 @@ under the License.
                     <file>${project.build.directory}/${project.artifactId}-${project.version}-source-release.${atr-release-type}</file>
                     <file>${project.build.directory}/${project.artifactId}-${project.version}-source-release.${atr-release-type}.sha512</file>
                     <file>${project.build.directory}/${project.artifactId}-${project.version}-source-release.${atr-release-type}.asc</file>
+                    <file>${project.build.directory}/${project.artifactId}-${project.version}-cyclonedx.json</file>
+                    <file>${project.build.directory}/${project.artifactId}-${project.version}-cyclonedx.json.sha512</file>
+                    <file>${project.build.directory}/${project.artifactId}-${project.version}-cyclonedx.json.asc</file>
                   </files>
                 </configuration>
               </execution>


### PR DESCRIPTION
Fixes #360

Publish a CycloneDX SBOM for ASF releases using the existing push-to-atr profile.

This:

* uses CycloneDX Maven Plugin 2.9.3
* runs makeAggregateBom during package
* generates JSON only
* sets outputReactorProjects=false so multi-module builds produce one aggregate SBOM
* allows projects to disable generation with -Dcyclonedx.skip=true
* creates a SHA-512 checksum and signature for the SBOM
* uploads the SBOM, checksum, and signature to ATR alongside the source release artifacts
* does not add SBOM artifacts to the normal Maven Central deployment path

This keeps the current CycloneDX 1.6 behavior scoped to ATR while leaving broader publication for CycloneDX 1.7 / isExternal support.