### PR TITLE
Bump surefire-plugin, failsafe-plugin, surefire-report-plugin from 3.5.6 to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ under the License.
     <project.build.outputTimestamp>2026-06-25T18:51:10Z</project.build.outputTimestamp>
 
     <!-- common version for surefire, failsafe, and surefire-report plugins below -->
-    <surefire.version>3.5.6</surefire.version>
+    <surefire.version>3.6.0</surefire.version>
     <!-- common version for the resource bundle descriptor dependency and resource bundle -->
     <version.apache-resource-bundles>1.8</version.apache-resource-bundles>
     <!-- common version for maven-plugin and maven-plugin-report plugins below -->


### PR DESCRIPTION

https://github.com/apache/maven-surefire/releases/tag/surefire-3.6.0

Please refer to the main page for what's new https://maven.apache.org/surefire/ And the migration page https://maven.apache.org/surefire/maven-surefire-plugin/whats-new-3-6-0.html